### PR TITLE
⚡ Optimize MobileDropdown rendering performance

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -16,14 +16,14 @@ const Layout: React.FC<LayoutProps> = ({ children, pageTitle, showBackButton = f
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false)
   const [openDropdown, setOpenDropdown] = React.useState<string | null>(null)
 
-  const toggleDropdown = (dropdown: string) => {
-    setOpenDropdown(openDropdown === dropdown ? null : dropdown)
-  }
+  const toggleDropdown = React.useCallback((dropdown: string) => {
+    setOpenDropdown((prev) => (prev === dropdown ? null : dropdown))
+  }, [])
 
-  const closeMobileMenu = () => {
+  const closeMobileMenu = React.useCallback(() => {
     setMobileMenuOpen(false)
     setOpenDropdown(null)
-  }
+  }, [])
 
   return (
     <div className="min-h-screen">
@@ -85,7 +85,7 @@ const Layout: React.FC<LayoutProps> = ({ children, pageTitle, showBackButton = f
                   title={dropdown.title}
                   links={dropdown.links}
                   isOpen={openDropdown === dropdown.id}
-                  onToggle={() => toggleDropdown(dropdown.id)}
+                  onToggle={toggleDropdown}
                   onLinkClick={closeMobileMenu}
                 />
               ))}

--- a/src/components/MobileDropdown.tsx
+++ b/src/components/MobileDropdown.tsx
@@ -23,12 +23,12 @@ const MobileDropdown = React.memo<MobileDropdownProps>(({
     onToggle(id)
   }, [id, onToggle])
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+  const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       handleToggle()
     }
-  }
+  }, [handleToggle])
 
   return (
     <div>

--- a/src/components/MobileDropdown.tsx
+++ b/src/components/MobileDropdown.tsx
@@ -7,11 +7,11 @@ interface MobileDropdownProps {
   title: string
   links: DropdownLink[]
   isOpen: boolean
-  onToggle: () => void
+  onToggle: (id: string) => void
   onLinkClick: () => void
 }
 
-const MobileDropdown: React.FC<MobileDropdownProps> = ({
+const MobileDropdown: React.FC<MobileDropdownProps> = React.memo(({
   id,
   title,
   links,
@@ -19,17 +19,21 @@ const MobileDropdown: React.FC<MobileDropdownProps> = ({
   onToggle,
   onLinkClick,
 }) => {
+  const handleToggle = React.useCallback(() => {
+    onToggle(id)
+  }, [id, onToggle])
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
-      onToggle()
+      handleToggle()
     }
   }
 
   return (
     <div>
       <button
-        onClick={onToggle}
+        onClick={handleToggle}
         onKeyDown={handleKeyDown}
         className="w-full text-left text-white hover:bg-white/10 transition px-3 py-2 rounded flex justify-between items-center"
         aria-expanded={isOpen}
@@ -59,6 +63,8 @@ const MobileDropdown: React.FC<MobileDropdownProps> = ({
       )}
     </div>
   )
-}
+})
+
+MobileDropdown.displayName = "MobileDropdown"
 
 export default MobileDropdown

--- a/src/components/MobileDropdown.tsx
+++ b/src/components/MobileDropdown.tsx
@@ -11,7 +11,7 @@ interface MobileDropdownProps {
   onLinkClick: () => void
 }
 
-const MobileDropdown: React.FC<MobileDropdownProps> = React.memo(({
+const MobileDropdown = React.memo<MobileDropdownProps>(({
   id,
   title,
   links,


### PR DESCRIPTION
### 💡 What:
The optimization involves memoizing the `MobileDropdown` component using `React.memo` and ensuring that the functions passed to it as props have stable references. Specifically, the `onToggle` prop was changed from an anonymous function created in a `map` loop to a stable function memoized with `useCallback` in the `Layout` component.

### 🎯 Why:
In the original code, `Layout.tsx` was passing `() => toggleDropdown(dropdown.id)` to each `MobileDropdown` inside a `map` loop. This created a new function reference on every render of `Layout`, causing every `MobileDropdown` to re-render even if its state hadn't changed. This is inefficient, especially given the large number of links in the navigation data.

### 📊 Measured Improvement:
While a runtime profiling environment was not available in the sandbox, this is a standard React performance optimization. By using `React.memo` and stable function references:
1.  **Re-render reduction:** When toggling one dropdown, only the affected `MobileDropdown` components (the one opening/closing and the one previously open) will re-render, instead of all components in the `navigationData` list.
2.  **Memory efficiency:** Fewer function objects are created during each render cycle of the `Layout` component.
3.  **Scalability:** The performance benefit scales with the number of items in the navigation menu. Given that `navigationData` contains dozens of entries across multiple categories, this significantly reduces the work React has to do on each interaction.

---
*PR created automatically by Jules for task [8690863724418220667](https://jules.google.com/task/8690863724418220667) started by @splk3*