### PR TITLE
🧹 fix unused parameter 'id' in MobileDropdown.tsx function type

### DIFF
--- a/src/components/MobileDropdown.tsx
+++ b/src/components/MobileDropdown.tsx
@@ -7,7 +7,7 @@ interface MobileDropdownProps {
   title: string
   links: DropdownLink[]
   isOpen: boolean
-  onToggle: (id: string) => void
+  onToggle: (_id: string) => void
   onLinkClick: () => void
 }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an ESLint warning for an unused parameter 'id' in the `onToggle` function type definition within the `MobileDropdownProps` interface.

💡 **Why:** This improves maintainability and readability by ensuring the codebase is free of linting warnings and follows the convention of prefixing unused parameters with an underscore.

✅ **Verification:** 
- Ran `npm test` and all 7 tests for `MobileDropdown` passed.
- Code review confirmed the change is safe and follows TypeScript conventions.

✨ **Result:** The ESLint warning is resolved without changing the component's behavior.

---
*PR created automatically by Jules for task [16356612954898642010](https://jules.google.com/task/16356612954898642010) started by @splk3*