### PR TITLE
🧪 Add tests for DesktopDropdown component

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "clean": "gatsby clean"
+    "clean": "gatsby clean",
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",
@@ -27,6 +28,12 @@
     "gatsby-plugin-postcss": "^6.16.0",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.8",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "jsdom": "^26.0.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@vitejs/plugin-react": "^4.3.4"
   }
 }

--- a/src/components/__tests__/DesktopDropdown.test.tsx
+++ b/src/components/__tests__/DesktopDropdown.test.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import DesktopDropdown from '../DesktopDropdown'
+
+// Mock gatsby's Link component
+vi.mock('gatsby', () => ({
+  Link: ({ children, to, ...props }: any) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const mockLinks = [
+  { to: '/link1', label: 'Link 1' },
+  { to: '/link2', label: 'Link 2' },
+]
+
+describe('DesktopDropdown', () => {
+  const defaultProps = {
+    id: 'test',
+    title: 'Dropdown Title',
+    links: mockLinks,
+  }
+
+  it('renders the dropdown title', () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    expect(screen.getByText(/Dropdown Title/i)).toBeInTheDocument()
+  })
+
+  it('does not show links by default', () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('shows links on mouse enter and hides on mouse leave', async () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    const container = screen.getByText(/Dropdown Title/i).closest('div')!
+
+    fireEvent.mouseEnter(container)
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByText('Link 1')).toBeInTheDocument()
+    expect(screen.getByText('Link 2')).toBeInTheDocument()
+
+    fireEvent.mouseLeave(container)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('toggles links on button click', async () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    const button = screen.getByRole('button')
+
+    await userEvent.click(button)
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    await userEvent.click(button)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('handles keyboard navigation - Enter key', async () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    const button = screen.getByRole('button')
+
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('handles keyboard navigation - Space key', async () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    const button = screen.getByRole('button')
+
+    fireEvent.keyDown(button, { key: ' ' })
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(button, { key: ' ' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('handles keyboard navigation - Escape key', async () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    const button = screen.getByRole('button')
+
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(button, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('sets accessibility attributes correctly', async () => {
+    render(<DesktopDropdown {...defaultProps} />)
+    const button = screen.getByRole('button')
+
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+    expect(button).toHaveAttribute('aria-haspopup', 'true')
+    expect(button).toHaveAttribute('aria-controls', 'desktop-test-menu')
+
+    await userEvent.click(button)
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+
+    const menu = screen.getByRole('menu')
+    expect(menu).toHaveAttribute('id', 'desktop-test-menu')
+
+    const menuItems = screen.getAllByRole('menuitem')
+    expect(menuItems).toHaveLength(2)
+    expect(menuItems[0]).toHaveAttribute('href', '/link1')
+  })
+
+  it('applies right alignment class when align="right"', async () => {
+    render(<DesktopDropdown {...defaultProps} align="right" />)
+    const button = screen.getByRole('button')
+    await userEvent.click(button)
+
+    const menu = screen.getByRole('menu')
+    expect(menu).toHaveClass('right-0')
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+  },
+})


### PR DESCRIPTION
### 🧪 Testing Improvement: DesktopDropdown

#### 🎯 What
Addressed the missing test coverage for the `DesktopDropdown` component.

#### 📊 Coverage
The new test suite covers:
- **Rendering:** Correct display of title and links.
- **Interactions:**
  - Mouse hover (mouseenter/mouseleave) to open/close.
  - Click-to-toggle functionality.
- **Keyboard Navigation:** Support for `Enter`, `Space`, and `Escape` keys.
- **Accessibility:** Verification of `aria-expanded`, `aria-haspopup`, and `aria-controls` attributes.
- **Props:** Conditional alignment classes (`align="right"`).

#### ✨ Result
Improved reliability and maintainability of the navigation components by ensuring accessibility and interactive behaviors are correctly implemented and verified.

#### 🛠️ Technical Details
- Framework: Vitest + React Testing Library
- Environment: JSDOM
- Mocks: Custom mock for Gatsby's `Link` component.

---
*PR created automatically by Jules for task [6998267231642843908](https://jules.google.com/task/6998267231642843908) started by @splk3*